### PR TITLE
Fix handleRemoteDisk return type

### DIFF
--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -55,9 +55,9 @@ class DownloadExcel extends ExportToExcel
     /**
      * @param  ActionRequest  $request
      * @param  Action  $exportable
-     * @return array
+     * @return mixed
      */
-    public function handleRemoteDisk(ActionRequest $request, Action $exportable): array
+    public function handleRemoteDisk(ActionRequest $request, Action $exportable): mixed
     {
         $temporaryFilePath = config('excel.temporary_files.remote_prefix') . 'laravel-excel-' . Str::random(32) . '.' . $this->getDefaultExtension();
         $isStored          = Excel::store($exportable, $temporaryFilePath, config('excel.temporary_files.remote_disk'), $this->getWriterType());

--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -22,6 +22,11 @@ class DownloadExcel extends ExportToExcel
         return $this->name ?? __('Download Excel');
     }
 
+    /**
+     * @param  ActionRequest  $request
+     * @param  Action  $exportable
+     * @return mixed
+     */
     public function handle(ActionRequest $request, Action $exportable): mixed
     {
         if (config('excel.temporary_files.remote_disk')) {
@@ -45,6 +50,7 @@ class DownloadExcel extends ExportToExcel
             : Action::download(
                 $this->getDownloadUrl($response->getFile()->getPathname()),
                 $this->getFilename()
+            );
     }
 
     /**


### PR DESCRIPTION
Action::danger and Action::download in handleRemoteDisk return Action|ActionResponse instead of an array (I guess since Nova 4).